### PR TITLE
Add some rules

### DIFF
--- a/rules.txt
+++ b/rules.txt
@@ -36,6 +36,7 @@ referrer-spoof: firefox.com false
 * cloudfront.net script allow
 * code.jquery.com script allow
 * maxcdn.bootstrapcdn.com script allow
+* unpkg.com script allow
 
 #163
 163.com api.money.126.net script allow

--- a/rules.txt
+++ b/rules.txt
@@ -528,3 +528,6 @@ zhanqi.tv videojj.com dobest.com bfun.cn alivecdn.com cookie allow
 #Mozilla Developer Network
 developer.mozilla.org mdn.mozillademos.org frame allow
 developer.mozilla.org mdn.mozillademos.org script allow
+
+#qzone
+user.qzone.qq.com qzonestyle.gtimg.cn script allow

--- a/rules.txt
+++ b/rules.txt
@@ -523,3 +523,7 @@ zhanqi.tv videojj.com dobest.com bfun.cn alivecdn.com media allow
 zhanqi.tv videojj.com dobest.com bfun.cn alivecdn.com script allow
 zhanqi.tv videojj.com dobest.com bfun.cn alivecdn.com xhr allow
 zhanqi.tv videojj.com dobest.com bfun.cn alivecdn.com cookie allow
+
+#Mozilla Developer Network
+developer.mozilla.org mdn.mozillademos.org frame allow
+developer.mozilla.org mdn.mozillademos.org script allow


### PR DESCRIPTION
Hi,
  I added rules for the following reasons:
  - unpkg is used commonly loading scripts on npm.
  - mdn demos frame should'n be blocked
  - qzonestyle.gtimg.cn is just a image cdn for qzone

<strong>if i made something wrong, please let me know.</strong>

Thanks.